### PR TITLE
Replace unstable `drain` feature for Rust 1.0.0 stable compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@
 //!            vec!(Algae::A, Algae::B, Algae::A, Algae::A, Algae::B))
 //! ```
 
+use std::mem;
+
 /// Create the Lindenmayer System defined by an axiom of type `Vec<T>`, a rule function (or
 /// closure) which maps values of type `T` to vectors of values of type `T`, and the set of all
 /// possible values of type `T`.
@@ -107,11 +109,11 @@ impl<T, F> Iterator for LSystem<T, F> where T: Clone, F: FnMut(T) -> Vec<T> {
 
         // Otherwise, apply the production rules to the axiom to produce a new axiom for the
         // iteration level.
-        let mut new_axiom = Vec::new();
-        for element in self.axiom.clone().into_iter() {
-            new_axiom.extend((self.rules)(element).into_iter());
+        let old_axiom = mem::replace(&mut self.axiom, Vec::new());
+
+        for element in old_axiom.into_iter() {
+            self.axiom.extend((self.rules)(element).into_iter());
         }
-        self.axiom = new_axiom;
         Some(self.axiom.clone())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,6 @@
 //!            vec!(Algae::A, Algae::B, Algae::A, Algae::A, Algae::B))
 //! ```
 
-// Currently required for using `drain`.
-#![feature(collections_drain)]
-
 /// Create the Lindenmayer System defined by an axiom of type `Vec<T>`, a rule function (or
 /// closure) which maps values of type `T` to vectors of values of type `T`, and the set of all
 /// possible values of type `T`.
@@ -111,7 +108,7 @@ impl<T, F> Iterator for LSystem<T, F> where T: Clone, F: FnMut(T) -> Vec<T> {
         // Otherwise, apply the production rules to the axiom to produce a new axiom for the
         // iteration level.
         let mut new_axiom = Vec::new();
-        for element in self.axiom.drain(..) {
+        for element in self.axiom.clone().into_iter() {
             new_axiom.extend((self.rules)(element).into_iter());
         }
         self.axiom = new_axiom;


### PR DESCRIPTION
Right now, lsystem refuses to compile on the stable branch of Rust, since `drain` is considered unstable. See https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md#feature-staging - even including the `feature` compiler directive will still result in an error.

This PR replaces `drain` with a `clone` and `into_iter`. There's an extra memory copy required, but since the axiom is being cloned anyways to return, I don't think it's a huge problem. I'll look into seeing whether swaps can be used instead to avoid the extra copy.

(I'm using rustc 1.0.0 (a59de37e9 2015-05-13) (built 2015-05-14).)
